### PR TITLE
Padronizar formato da moeda

### DIFF
--- a/laravel/app/Http/Controllers/ContaController.php
+++ b/laravel/app/Http/Controllers/ContaController.php
@@ -24,7 +24,10 @@ class ContaController extends Controller
             $conta = $this->contaRepository->findByContaId($contaId);
 
             if ($conta !== null) {
-                return response()->json($conta);
+                return response()->json([
+                    'conta_id' => $conta->conta_id,
+                    'saldo' => $conta->getSaldo(),
+                ]);
             }
 
         }

--- a/laravel/app/Http/Controllers/TransacaoController.php
+++ b/laravel/app/Http/Controllers/TransacaoController.php
@@ -25,7 +25,10 @@ class TransacaoController extends Controller
 
             $conta = $this->transacaoService->processarTransacao($transacaoData);
 
-            return response()->json($conta, Response::HTTP_CREATED);
+            return response()->json([
+                'conta_id' => $conta->conta_id,
+                'valor' => $conta->getSaldo(),
+            ], Response::HTTP_CREATED);
         } catch (\Exception $e) {
             return response()->json(['error' => $e->getMessage()], Response::HTTP_NOT_FOUND);
         }

--- a/laravel/app/Models/Conta.php
+++ b/laravel/app/Models/Conta.php
@@ -29,4 +29,14 @@ class Conta extends Model
         }
         $this->attributes['saldo'] = $value;
     }
+
+    public function getSaldo(): float
+    {
+        return $this->currencyFormat($this->saldo);
+    }
+
+    public static function currencyFormat($value): float
+    {
+        return number_format($value, 2, '.', '');
+    }
 }

--- a/laravel/app/Models/Transacao.php
+++ b/laravel/app/Models/Transacao.php
@@ -26,4 +26,10 @@ class Transacao extends Model
     {
         return $this->belongsTo(Conta::class);
     }
+
+
+    public function getValor(): float
+    {
+        return Conta::currencyFormat($this->valor);
+    }
 }

--- a/laravel/database/migrations/2023_11_28_201224_create_contas_table.php
+++ b/laravel/database/migrations/2023_11_28_201224_create_contas_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('contas', function (Blueprint $table) {
             $table->id('conta_id');
-            $table->float('saldo');
+            $table->decimal('saldo', 12, 2);
         });
     }
 

--- a/laravel/database/migrations/2023_11_30_000106_create_transacoes_table.php
+++ b/laravel/database/migrations/2023_11_30_000106_create_transacoes_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->integer('conta_id');
             $table->char('forma_pagamento', 1);
-            $table->float('valor');
+            $table->decimal('valor', 12, 2);
         });
     }
 

--- a/laravel/tests/Feature/ContaControllerTest.php
+++ b/laravel/tests/Feature/ContaControllerTest.php
@@ -9,12 +9,12 @@ use Tests\TestCase;
 
 class ContaControllerTest extends TestCase
 {
-    private $contaId;
+    private $contaId = 9999;
 
     public function testCriarConta(): void
     {
         $data = [
-            'conta_id' => 1234,
+            'conta_id' => $this->contaId,
             'saldo' => 12.34,
         ];
 
@@ -22,8 +22,6 @@ class ContaControllerTest extends TestCase
 
         $response->assertStatus(201)
             ->assertJson($data);
-
-        $this->contaId = $data['conta_id'];
     }
 
     protected function tearDown(): void

--- a/laravel/tests/Feature/TransacaoControllerTest.php
+++ b/laravel/tests/Feature/TransacaoControllerTest.php
@@ -33,7 +33,7 @@ class TransacaoControllerTest extends TestCase
         $response->assertStatus(201)
             ->assertJson([
                 'conta_id' => $payload['conta_id'],
-                'saldo' => $saldoAtualizado,
+                'valor' => Conta::currencyFormat($saldoAtualizado)
             ]);
 
         $transacao->delete();

--- a/laravel/tests/Unit/TransacaoServiceTest.php
+++ b/laravel/tests/Unit/TransacaoServiceTest.php
@@ -20,7 +20,7 @@ class TransacaoServiceTest extends TestCase
 
         $transacaoData = [
             'conta_id' => $conta->conta_id,
-            'valor' => 100.00,
+            'valor' => 100.12,
             'forma_pagamento' => 'D'
         ];
 
@@ -39,8 +39,9 @@ class TransacaoServiceTest extends TestCase
         $contaAtualizada = Conta::find($conta->conta_id);
 
         $valorDebitado = $transacaoData['valor'] * $taxaRepository->getTaxa($transacaoData['forma_pagamento']);
+        $valorEsperado = number_format($conta->getSaldo() - $valorDebitado, 2, '.', '');
 
-        $this->assertEquals($conta->saldo - $valorDebitado, $contaAtualizada->saldo);
+        $this->assertEquals($valorEsperado, $contaAtualizada->getSaldo());
 
         $transacao->delete();
         $conta->delete();


### PR DESCRIPTION
Cria e usa no sistema uma classe para padronizar o formato de casas decimais que usaremos nos atributos.
Resolves #22 